### PR TITLE
Fix Firefox manifest warning for version_name property

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -55,7 +55,7 @@ This extension maintains **separate manifest files** due to incompatible Manifes
 "browser_specific_settings": {
   "gecko": {
     "id": "github-bookmarked-issues@extensions",
-    "strict_min_version": "128.0",
+    "strict_min_version": "142.0",
     "data_collection_permissions": {"required": ["none"]}
   }
 }
@@ -168,7 +168,8 @@ The script outputs a `GITHUB_AUTH_STATE` value to add to `.env`. Sessions expire
 
 ### Version Tracking
 
-Dev builds include git commit info in `version_name` (visible in `chrome://extensions` or `about:addons`):
+Dev builds include git commit info in `version_name` (Chrome only, visible in `chrome://extensions`).
+Firefox does not support `version_name`; it warns about unknown manifest properties at runtime.
 
 | Build Type                 | version_name Example                      |
 |----------------------------|-------------------------------------------|

--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -7,7 +7,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "github-bookmarked-issues@extensions",
-      "strict_min_version": "128.0",
+      "strict_min_version": "142.0",
       "data_collection_permissions": {
         "required": ["none"]
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:chrome && npm run build:firefox",
     "postbuild": "npm run lint",
     "dev:watch": "node scripts/dev-watch.js",
-    "lint": "web-ext lint --source-dir=build/firefox --artifacts-dir=build",
+    "lint": "web-ext lint --source-dir=build/firefox --artifacts-dir=build --warnings-as-errors",
     "test": "playwright test",
     "test:chrome": "playwright test --project=chromium",
     "test:visual": "playwright test --grep @visual",

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -94,7 +94,10 @@ async function build() {
 
   const versionName = getVersionName(manifest.version);
   if (versionName !== manifest.version) {
-    manifest.version_name = versionName;
+    // version_name is Chrome-specific; Firefox warns about unknown properties
+    if (browser === 'chrome') {
+      manifest.version_name = versionName;
+    }
     console.log(`  Version: ${versionName}`);
   }
 


### PR DESCRIPTION
Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)